### PR TITLE
patched signal cable wire

### DIFF
--- a/src/main/java/org/terasology/signalling/blockFamily/SignalCableBlockFamilyFactory.java
+++ b/src/main/java/org/terasology/signalling/blockFamily/SignalCableBlockFamilyFactory.java
@@ -15,91 +15,207 @@
  */
 package org.terasology.signalling.blockFamily;
 
-import org.terasology.blockNetwork.BlockNetworkUtil;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import gnu.trove.iterator.TByteObjectIterator;
+import gnu.trove.map.TByteObjectMap;
+import gnu.trove.map.hash.TByteObjectHashMap;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.SideBitFlag;
 import org.terasology.math.geom.Vector3i;
-import org.terasology.signalling.components.SignalConductorComponent;
-import org.terasology.signalling.components.SignalConsumerComponent;
-import org.terasology.signalling.components.SignalProducerComponent;
+import org.terasology.naming.Name;
+import org.terasology.registry.In;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockBuilderHelper;
 import org.terasology.world.block.BlockComponent;
-import org.terasology.world.block.family.ConnectionCondition;
+import org.terasology.world.block.BlockUri;
+import org.terasology.world.block.family.BlockFamily;
+import org.terasology.world.block.family.BlockFamilyFactory;
 import org.terasology.world.block.family.RegisterBlockFamilyFactory;
+import org.terasology.world.block.family.UpdatesWithNeighboursFamily;
 import org.terasology.world.block.family.UpdatesWithNeighboursFamilyFactory;
+import org.terasology.world.block.items.BlockItemComponent;
+import org.terasology.world.block.items.OnBlockItemPlaced;
+import org.terasology.world.block.loader.BlockFamilyDefinition;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 
 /**
  * @author Marcin Sciesinski <marcins78@gmail.com>
  */
 @RegisterBlockFamilyFactory("cable")
-public class SignalCableBlockFamilyFactory extends UpdatesWithNeighboursFamilyFactory {
-    public SignalCableBlockFamilyFactory() {
-        super(new SignalCableConnectionCondition(), (byte) 63);
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class SignalCableBlockFamilyFactory extends BaseComponentSystem implements BlockFamilyFactory  {
+    
+    
+    @In
+    private WorldProvider worldProvider;
+    
+    @In
+    private BlockEntityRegistry blockEntityRegistry;
+    
+    private static final ImmutableSet<String> BLOCK_NAMES = ImmutableSet.of(
+            UpdatesWithNeighboursFamilyFactory.NO_CONNECTIONS,
+            UpdatesWithNeighboursFamilyFactory.ONE_CONNECTION,
+            UpdatesWithNeighboursFamilyFactory.TWO_CONNECTIONS_LINE,
+            UpdatesWithNeighboursFamilyFactory.TWO_CONNECTIONS_CORNER,
+            UpdatesWithNeighboursFamilyFactory.THREE_CONNECTIONS_CORNER,
+            UpdatesWithNeighboursFamilyFactory.THREE_CONNECTIONS_T,
+            UpdatesWithNeighboursFamilyFactory.FOUR_CONNECTIONS_CROSS,
+            UpdatesWithNeighboursFamilyFactory.FOUR_CONNECTIONS_SIDE,
+            UpdatesWithNeighboursFamilyFactory.FIVE_CONNECTIONS,
+            UpdatesWithNeighboursFamilyFactory.SIX_CONNECTIONS);
+    
+    private static final Map<String, Byte> DEFAULT_SHAPE_MAPPING = ImmutableMap.<String, Byte>builder()
+            .put(UpdatesWithNeighboursFamilyFactory.NO_CONNECTIONS, (byte) 0)
+            .put(UpdatesWithNeighboursFamilyFactory.ONE_CONNECTION, SideBitFlag.getSides(Side.BACK))
+            
+            .put(UpdatesWithNeighboursFamilyFactory.TWO_CONNECTIONS_LINE, SideBitFlag.getSides(Side.BACK, Side.FRONT))
+            .put(UpdatesWithNeighboursFamilyFactory.TWO_CONNECTIONS_CORNER, SideBitFlag.getSides(Side.LEFT, Side.BACK))
+            
+            .put(UpdatesWithNeighboursFamilyFactory.THREE_CONNECTIONS_CORNER, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.TOP))
+            .put(UpdatesWithNeighboursFamilyFactory.THREE_CONNECTIONS_T, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT))
+            
+            .put(UpdatesWithNeighboursFamilyFactory.FOUR_CONNECTIONS_CROSS, SideBitFlag.getSides(Side.RIGHT, Side.LEFT, Side.BACK, Side.FRONT))
+            .put(UpdatesWithNeighboursFamilyFactory.FOUR_CONNECTIONS_SIDE, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT, Side.TOP))
+            
+            .put(UpdatesWithNeighboursFamilyFactory.FIVE_CONNECTIONS, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT, Side.TOP, Side.BOTTOM))
+            .put(UpdatesWithNeighboursFamilyFactory.SIX_CONNECTIONS, (byte) 63)
+            .build();
+    
+    
+    
+    public SignalCableBlockFamilyFactory(){
     }
-
-    private static class SignalCableConnectionCondition implements ConnectionCondition {
-        @Override
-        public boolean isConnectingTo(Vector3i blockLocation, Side connectSide, WorldProvider worldProvider, BlockEntityRegistry blockEntityRegistry) {
+    
+    @Override
+    public BlockFamily createBlockFamily(BlockFamilyDefinition definition, BlockBuilderHelper blockBuilder) {
+        TByteObjectMap<String>[] basicBlocks = new TByteObjectMap[7];
+        TByteObjectMap<Block> blocksForConnections = new TByteObjectHashMap<>();
+        
+        addConnections(basicBlocks, 0,  UpdatesWithNeighboursFamilyFactory.NO_CONNECTIONS);
+        addConnections(basicBlocks, 1,  UpdatesWithNeighboursFamilyFactory.ONE_CONNECTION);
+        addConnections(basicBlocks, 2,  UpdatesWithNeighboursFamilyFactory.TWO_CONNECTIONS_LINE);
+        addConnections(basicBlocks, 2,  UpdatesWithNeighboursFamilyFactory.TWO_CONNECTIONS_CORNER);
+        addConnections(basicBlocks, 3,  UpdatesWithNeighboursFamilyFactory.THREE_CONNECTIONS_CORNER);
+        addConnections(basicBlocks, 3,  UpdatesWithNeighboursFamilyFactory.THREE_CONNECTIONS_T);
+        addConnections(basicBlocks, 4,  UpdatesWithNeighboursFamilyFactory.FOUR_CONNECTIONS_CROSS);
+        addConnections(basicBlocks, 4,  UpdatesWithNeighboursFamilyFactory.FOUR_CONNECTIONS_SIDE);
+        addConnections(basicBlocks, 5,  UpdatesWithNeighboursFamilyFactory.FIVE_CONNECTIONS);
+        addConnections(basicBlocks, 6,  UpdatesWithNeighboursFamilyFactory.SIX_CONNECTIONS);
+        
+        BlockUri blockUri = new BlockUri(definition.getUrn());
+        
+        // Now make sure we have all combinations based on the basic set (above) and rotations
+        for (byte connections = 0; connections < 64; connections++) {
+            // Only the allowed connections should be created
+            if ((connections & (byte)63) == connections) {
+                Block block = constructBlockForConnections(connections, blockBuilder, definition, basicBlocks);
+                if (block == null) {
+                    throw new IllegalStateException("Unable to find correct block definition for connections: " + connections);
+                }
+                block.setUri(new BlockUri(blockUri, new Name(String.valueOf(connections))));
+                blocksForConnections.put(connections, block);
+            }
+        }
+        
+        final Block archetypeBlock = blocksForConnections.get(SideBitFlag.getSides(Side.RIGHT, Side.LEFT));
+//        return new SignalUpdateFamily(blockUri, definition.getCategories(), archetypeBlock, blocksForConnections, (byte)63);
+        return new SignalUpdateFamily(blockUri, definition.getCategories(),
+                archetypeBlock, blocksForConnections, (byte)63);
+    }
+    
+    private void addConnections(TByteObjectMap<String>[] basicBlocks, int index, String connections) {
+        if (basicBlocks[index] == null) {
+            basicBlocks[index] = new TByteObjectHashMap<>();
+        }
+        Byte val = DEFAULT_SHAPE_MAPPING.get(connections);
+        if (val != null) {
+            basicBlocks[index].put(DEFAULT_SHAPE_MAPPING.get(connections), connections);
+        }
+    }
+    
+    private Block constructBlockForConnections(final byte connections, final BlockBuilderHelper blockBuilder,
+                                               BlockFamilyDefinition definition, TByteObjectMap<String>[] basicBlocks) {
+        int connectionCount = SideBitFlag.getSides(connections).size();
+        TByteObjectMap<String> possibleBlockDefinitions = basicBlocks[connectionCount];
+        final TByteObjectIterator<String> blockDefinitionIterator = possibleBlockDefinitions.iterator();
+        while (blockDefinitionIterator.hasNext()) {
+            blockDefinitionIterator.advance();
+            final byte originalConnections = blockDefinitionIterator.key();
+            final String section = blockDefinitionIterator.value();
+            Rotation rot = getRotationToAchieve(originalConnections, connections);
+            if (rot != null) {
+                return blockBuilder.constructTransformedBlock(definition, section, rot);
+            }
+        }
+        return null;
+    }
+    
+    private Rotation getRotationToAchieve(byte source, byte target) {
+        Collection<Side> originalSides = SideBitFlag.getSides(source);
+        
+        Iterable<Rotation> rotations = /*horizontalOnly ? Rotation.horizontalRotations() :*/ Rotation.values();
+        for (Rotation rot : rotations) {
+            Set<Side> transformedSides = Sets.newHashSet();
+            transformedSides.addAll(originalSides.stream().map(rot::rotate).collect(Collectors.toList()));
+            
+            byte transformedSide = SideBitFlag.getSides(transformedSides);
+            if (transformedSide == target) {
+                return rot;
+            }
+        }
+        return null;
+    }
+    
+    @ReceiveEvent(components = {BlockItemComponent.class})
+    public void onPlaceBlock(OnBlockItemPlaced event, EntityRef entity) {
+        BlockComponent blockComponent = event.getPlacedBlock().getComponent(BlockComponent.class);
+        if (blockComponent == null) {
+            return;
+        }
+        
+        Vector3i targetBlock = blockComponent.getPosition();
+        processUpdateForBlockLocation(targetBlock);
+    }
+    
+    private void processUpdateForBlockLocation(Vector3i blockLocation) {
+        for (Side side : Side.values()) {
             Vector3i neighborLocation = new Vector3i(blockLocation);
-            neighborLocation.add(connectSide.getVector3i());
-
-            byte sourceConnection = BlockNetworkUtil.getSourceConnections(worldProvider.getBlock(blockLocation), SideBitFlag.getSide(connectSide));
-
-            boolean input = false;
-            boolean output = false;
-            EntityRef blockEntity = blockEntityRegistry.getBlockEntityAt(blockLocation);
-            for (SignalConductorComponent.ConnectionGroup connectionGroup : blockEntity.getComponent(SignalConductorComponent.class).connectionGroups) {
-                input |= (connectionGroup.inputSides & sourceConnection) > 0;
-                output |= (connectionGroup.outputSides & sourceConnection) > 0;
-            }
-
-            if (!input && !output) {
-                return false;
-            }
-            EntityRef neighborEntity = blockEntityRegistry.getBlockEntityAt(neighborLocation);
-            return neighborEntity != null && connectsToNeighbor(connectSide, input, output, neighborEntity);
-        }
-
-        private boolean connectsToNeighbor(Side connectSide, boolean input, boolean output, EntityRef neighborEntity) {
-            final Side oppositeDirection = connectSide.reverse();
-
-            Block block = neighborEntity.getComponent(BlockComponent.class).getBlock();
-
-            final SignalConductorComponent neighborConductorComponent = neighborEntity.getComponent(SignalConductorComponent.class);
-            if (neighborConductorComponent != null) {
-                if (output) {
-                    for (SignalConductorComponent.ConnectionGroup connectionGroup : neighborConductorComponent.connectionGroups) {
-                        if (SideBitFlag.hasSide(BlockNetworkUtil.getResultConnections(block, connectionGroup.inputSides), oppositeDirection)) {
-                            return true;
-                        }
-                    }
-                }
-                if (input) {
-                    for (SignalConductorComponent.ConnectionGroup connectionGroup : neighborConductorComponent.connectionGroups) {
-                        if (SideBitFlag.hasSide(BlockNetworkUtil.getResultConnections(block, connectionGroup.inputSides), oppositeDirection)) {
-                            return true;
-                        }
+            neighborLocation.add(side.getVector3i());
+            if (worldProvider.isBlockRelevant(neighborLocation)) {
+                Block neighborBlock = worldProvider.getBlock(neighborLocation);
+                final BlockFamily blockFamily = neighborBlock.getBlockFamily();
+                if (blockFamily instanceof SignalUpdateFamily) {
+                    UpdatesWithNeighboursFamily neighboursFamily = (UpdatesWithNeighboursFamily) blockFamily;
+                    Block neighborBlockAfterUpdate = neighboursFamily.getBlockForNeighborUpdate(worldProvider,blockEntityRegistry,neighborLocation, neighborBlock);
+                    if (neighborBlock != neighborBlockAfterUpdate) {
+                        worldProvider.setBlock(neighborLocation, neighborBlockAfterUpdate);
                     }
                 }
             }
-
-            if (output) {
-                final SignalConsumerComponent neighborConsumerComponent = neighborEntity.getComponent(SignalConsumerComponent.class);
-                if (neighborConsumerComponent != null && SideBitFlag.hasSide(BlockNetworkUtil.getResultConnections(block, neighborConsumerComponent.connectionSides), oppositeDirection)) {
-                    return true;
-                }
-            }
-            if (input) {
-                final SignalProducerComponent neighborProducerComponent = neighborEntity.getComponent(SignalProducerComponent.class);
-                if (neighborProducerComponent != null && SideBitFlag.hasSide(BlockNetworkUtil.getResultConnections(block, neighborProducerComponent.connectionSides), oppositeDirection)) {
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
+    
+    
+    @Override
+    public Set<String> getSectionNames() {
+        return BLOCK_NAMES;
+    }
+    
+    
+    
 }

--- a/src/main/java/org/terasology/signalling/blockFamily/SignalUpdateFamily.java
+++ b/src/main/java/org/terasology/signalling/blockFamily/SignalUpdateFamily.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.signalling.blockFamily;
+
+import gnu.trove.map.TByteObjectMap;
+import org.terasology.blockNetwork.BlockNetworkUtil;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.math.Side;
+import org.terasology.math.SideBitFlag;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.signalling.components.SignalConductorComponent;
+import org.terasology.signalling.components.SignalConsumerComponent;
+import org.terasology.signalling.components.SignalProducerComponent;
+import org.terasology.world.BlockEntityRegistry;
+import org.terasology.world.WorldProvider;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockComponent;
+import org.terasology.world.block.BlockUri;
+import org.terasology.world.block.family.ConnectionCondition;
+import org.terasology.world.block.family.UpdatesWithNeighboursFamily;
+
+import java.util.List;
+import java.util.Locale;
+
+public class SignalUpdateFamily extends UpdatesWithNeighboursFamily {
+    
+    private byte connectionSides;
+    private TByteObjectMap<Block> blocks;
+    
+    public SignalUpdateFamily(BlockUri blockUri, List<String> categories, Block archetypeBlock, TByteObjectMap<Block> blocks, byte connectionSides) {
+        super(null, blockUri, categories, archetypeBlock, blocks, connectionSides);
+        this.connectionSides = connectionSides;
+        this.blocks = blocks;
+    
+    }
+    
+    @Override
+    public Block getBlockForPlacement(WorldProvider worldProvider, BlockEntityRegistry blockEntityRegistry, Vector3i location, Side attachmentSide, Side direction) {
+        byte connections = 0;
+        for (Side connectSide : SideBitFlag.getSides(connectionSides)) {
+            if (connectionCondition(location, connectSide,worldProvider,blockEntityRegistry)) {
+                connections += SideBitFlag.getSide(connectSide);
+            }
+        }
+        return blocks.get(connections);
+    }
+    
+    @Override
+    public Block getBlockForNeighborUpdate(WorldProvider worldProvider, BlockEntityRegistry blockEntityRegistry, Vector3i location, Block oldBlock) {
+        byte connections = 0;
+        for (Side connectSide : SideBitFlag.getSides(connectionSides)) {
+            if (connectionCondition(location, connectSide,worldProvider,blockEntityRegistry)) {
+                connections += SideBitFlag.getSide(connectSide);
+            }
+        }
+        return blocks.get(connections);
+    }
+    
+    
+    public boolean connectionCondition(Vector3i blockLocation, Side connectSide,WorldProvider worldProvider,BlockEntityRegistry blockEntityRegistry) {
+        Vector3i neighborLocation = new Vector3i(blockLocation);
+        neighborLocation.add(connectSide.getVector3i());
+        
+        byte sourceConnection = BlockNetworkUtil.getSourceConnections(worldProvider.getBlock(blockLocation), SideBitFlag.getSide(connectSide));
+        
+        boolean input = false;
+        boolean output = false;
+        
+        Prefab prefab = this.getArchetypeBlock().getPrefab().get();
+        for (SignalConductorComponent.ConnectionGroup connectionGroup : prefab.getComponent(SignalConductorComponent.class).connectionGroups) {
+            input |= (connectionGroup.inputSides & sourceConnection) > 0;
+            output |= (connectionGroup.outputSides & sourceConnection) > 0;
+        }
+        
+        
+        if (!input && !output) {
+            return false;
+        }
+        EntityRef neighborEntity = blockEntityRegistry.getBlockEntityAt(neighborLocation);
+        return neighborEntity != null && connectsToNeighbor(connectSide, input, output, neighborEntity);
+    }
+    
+    
+    private boolean connectsToNeighbor(Side connectSide, boolean input, boolean output, EntityRef neighborEntity) {
+        final Side oppositeDirection = connectSide.reverse();
+        
+        Block block = neighborEntity.getComponent(BlockComponent.class).getBlock();
+        
+        final SignalConductorComponent neighborConductorComponent = neighborEntity.getComponent(SignalConductorComponent.class);
+        if (neighborConductorComponent != null) {
+            if (output) {
+                for (SignalConductorComponent.ConnectionGroup connectionGroup : neighborConductorComponent.connectionGroups) {
+                    if (SideBitFlag.hasSide(BlockNetworkUtil.getResultConnections(block, connectionGroup.inputSides), oppositeDirection)) {
+                        return true;
+                    }
+                }
+            }
+            if (input) {
+                for (SignalConductorComponent.ConnectionGroup connectionGroup : neighborConductorComponent.connectionGroups) {
+                    if (SideBitFlag.hasSide(BlockNetworkUtil.getResultConnections(block, connectionGroup.inputSides), oppositeDirection)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        
+        if (output) {
+            final SignalConsumerComponent neighborConsumerComponent = neighborEntity.getComponent(SignalConsumerComponent.class);
+            if (neighborConsumerComponent != null && SideBitFlag.hasSide(BlockNetworkUtil.getResultConnections(block, neighborConsumerComponent.connectionSides), oppositeDirection)) {
+                return true;
+            }
+        }
+        if (input) {
+            final SignalProducerComponent neighborProducerComponent = neighborEntity.getComponent(SignalProducerComponent.class);
+            if (neighborProducerComponent != null && SideBitFlag.hasSide(BlockNetworkUtil.getResultConnections(block, neighborProducerComponent.connectionSides), oppositeDirection)) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+    
+}


### PR DESCRIPTION
This resolves the placement problem with signal cables. I need access to the getArchetypeBlock() but this is not available in the ConnectionCondition so I re-implemented everything backwards from there. This is for the latest version of Terasology. This does not use the tweaks for block families, but rather works around the limitations of the current block family model.

https://github.com/MovingBlocks/Terasology/pull/3085